### PR TITLE
Add natural earth provinces

### DIFF
--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -156,7 +156,8 @@ class Regions(object):
         return key
 
     def __repr__(self):
-        abbrevs = " ".join(self.abbrevs)
+        abbrevs = ['None' if abbr is None else abbr for abbr in self.abbrevs]
+        abbrevs = " ".join(abbrevs)
         if self.source:
             msg = "{} '{}' Regions ({})\n{}"
             msg = msg.format(len(self.numbers), self.name, self.source, abbrevs)

--- a/regionmask/defined_regions/natural_earth.py
+++ b/regionmask/defined_regions/natural_earth.py
@@ -136,6 +136,8 @@ class natural_earth_cls(object):
 
         self._ocean_basins_50 = None
 
+        self._states_provinces_10 = None
+
     def __repr__(self):
         return "Combines Region Definitions from 'http://www.naturalearthdata.com'."
 

--- a/regionmask/defined_regions/natural_earth.py
+++ b/regionmask/defined_regions/natural_earth.py
@@ -258,5 +258,17 @@ class natural_earth_cls(object):
             self._ocean_basins_50 = regs
         return self._ocean_basins_50
 
+    @property
+    def states_provinces_10(self):
+        if self._states_provinces_10 is None:
+            opt = dict(
+                resolution="10m",
+                category="cultural",
+                name="admin_1_states_provinces",
+                title="Natural Earth States/Provinces: 10m"
+            )
+
+            self._states_provinces_10 = _obtain_ne(**opt)
+        return self._states_provinces_10
 
 natural_earth = natural_earth_cls()


### PR DESCRIPTION
Added States/Provinces for all countries, expanding from just US states.

```python
    @property
    def states_provinces_10(self):
        if self._states_provinces_10 is None:
            opt = dict(
                resolution="10m",
                category="cultural",
                name="admin_1_states_provinces",
                title="Natural Earth States/Provinces: 10m"
            )

            self._states_provinces_10 = _obtain_ne(**opt)
        return self._states_provinces_10
```

These shapefiles had some Nonetype values in the abbreviations metadata which threw errors for me so I just added this line. I don't think it's the best way to fix this, but it shouldn't affect the behavior of anything else and I wasn't sure how else to do it:
```python
abbrevs = ['None' if abbr is None else abbr for abbr in self.abbrevs]
abbrevs = " ".join(abbrevs)
```